### PR TITLE
emulate aligned_alloc for MSVC regardless of declared C++ version

### DIFF
--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -151,10 +151,8 @@ template<> struct VLEN<double> { static constexpr size_t val=2; };
 
 // the __MINGW32__ part in the conditional below works around the problem that
 // the standard C++ library on Windows does not provide aligned_alloc() even
-// though the MinGW compiler advertises C++17 compliance.
-// MSVC does not trigger this problem, since it apparently always sets
-// __cplusplus to 199711L ...
-#if (__cplusplus >= 201703L) && (!defined(__MINGW32__))
+// though the MinGW compiler and MSVC may advertise C++17 compliance.
+#if (__cplusplus >= 201703L) && (!defined(__MINGW32__)) && (!defined(_MSC_VER))
 inline void *aligned_alloc(size_t align, size_t size)
   {
   // aligned_alloc() requires that the requested size is a multiple of "align"


### PR DESCRIPTION
Recent versions of MSVC (apparently Visual Studio 2017 and later) now [advertise more current C++ compliance](https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/) and are subject to the `aligned_alloc` bug that was biting MinGW users. The fix for MinGW will have to apply for these clients as well.