### PR TITLE
Enhancement: Add prev_good_size to calculate fast FFT length smaller than N

### DIFF
--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -460,14 +460,9 @@ struct util // hack to avoid duplicate symbols
     if (n<=12) return n;
 
     size_t bestfound = 1;
-    size_t f11 = 1;
-    while (f11 <= n)
-    {
-      size_t f117 = f11;
-      while (f117 <= n)
-      {
-        size_t f1175 = f117;
-        while (f1175 <= n)
+	for (size_t f11 = 1;f11 <= n; f11 *= 11)
+      for (size_t f117 = f11; f117 <= n; f117 *= 7)
+        for (size_t f1175 = f117; f1175 <= n; f1175 *= 5)
         {
           size_t x = f1175;
           while (x*2 <= n) x *= 2;
@@ -480,12 +475,7 @@ struct util // hack to avoid duplicate symbols
               
             if (x > bestfound) bestfound = x;
           }
-          f1175 *= 5;
         }
-        f117 *= 7;
-      }
-      f11 *= 11;
-    }
     return bestfound;
   }
 
@@ -495,8 +485,7 @@ struct util // hack to avoid duplicate symbols
     if (n<=6) return n;
 
     size_t bestfound = 1;
-    size_t f5 = 1;
-    while (f5 <= n)
+    for (size_t f5 = 1; f5 <= n; f5 *= 5)
     {
       size_t x = f5;
       while (x*2 <= n) x *= 2;
@@ -509,7 +498,6 @@ struct util // hack to avoid duplicate symbols
       
         if (x > bestfound) bestfound = x;
       }
-      f5 *= 5;
     }
     return bestfound;
   }

--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -469,17 +469,17 @@ struct util // hack to avoid duplicate symbols
         size_t f1175 = f117;
         while (f1175 <= n)
         {
-          // Instead of searching all combinations of 2 and 3
-          // we search in a stair-step pattern where we either divide by 2 or multiply by 3.
-          // This reduces search space from O(f2max * f3max) to O(f2max + f3max)
           size_t x = f1175;
           while (x*2 <= n) x *= 2;
           if (x > bestfound) bestfound = x;
-          while (x <= n && x&1==0)
-          {
-            (x*3 <= n) ? (x *= 3) : (x /= 2);
-            if (x > bestfound) bestfound = x;
-          }
+            while (true) 
+            {
+              if (x * 3 <= n) x *= 3;
+              else if (x % 2 == 0) x /= 2;
+              else break;
+                
+              if (x > bestfound) bestfound = x;
+            }
           f1175 *= 5;
         }
         f117 *= 7;
@@ -498,17 +498,17 @@ struct util // hack to avoid duplicate symbols
     size_t f5 = 1;
     while (f5 <= n)
     {
-      // Instead of searching all combinations of 2 and 3
-      // we search in a stair-step pattern where we either divide by 2 or multiply by 3.
-      // This reduces search space from O(f2max * f3max) to O(f2max + f3max)
       size_t x = f5;
       while (x*2 <= n) x *= 2;
       if (x > bestfound) bestfound = x;
-      while (x <= n && x&1==0)
-      {
-        (x*3 <= n) ? (x *= 3) : (x /= 2);
-        if (x > bestfound) bestfound = x;
-      }
+	  while (true) 
+	  {
+	    if (x * 3 <= n) x *= 3;
+	    else if (x % 2 == 0) x /= 2;
+	    else break;
+	  
+	    if (x > bestfound) bestfound = x;
+	  }
       f5 *= 5;
     }
     return bestfound;

--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -454,6 +454,66 @@ struct util // hack to avoid duplicate symbols
     return bestfac;
     }
 
+  /* returns the largest composite of 2, 3, 5, 7 and 11 which is <= n */
+  static POCKETFFT_NOINLINE size_t prev_good_size_cmplx(size_t n)
+  {
+    if (n<=12) return n;
+
+    size_t bestfound = 1;
+    size_t f11 = 1;
+    while (f11 <= n)
+    {
+      size_t f117 = f11;
+      while (f117 <= n)
+      {
+        size_t f1175 = f117;
+        while (f1175 <= n)
+        {
+          // Instead of searching all combinations of 2 and 3
+          // we search in a stair-step pattern where we either divide by 2 or multiply by 3.
+          // This reduces search space from O(f2max * f3max) to O(f2max + f3max)
+          size_t x = f1175;
+          while (x*2 <= n) x *= 2;
+          if (x > bestfound) bestfound = x;
+          while (x <= n && x&1==0)
+          {
+            (x*3 <= n) ? (x *= 3) : (x /= 2);
+            if (x > bestfound) bestfound = x;
+          }
+          f1175 *= 5;
+        }
+        f117 *= 7;
+      }
+      f11 *= 11;
+    }
+    return bestfound;
+  }
+
+  /* returns the largest composite of 2, 3, 5 which is <= n */
+  static POCKETFFT_NOINLINE size_t prev_good_size_real(size_t n)
+  {
+    if (n<=6) return n;
+
+    size_t bestfound = 1;
+    size_t f5 = 1;
+    while (f5 <= n)
+    {
+      // Instead of searching all combinations of 2 and 3
+      // we search in a stair-step pattern where we either divide by 2 or multiply by 3.
+      // This reduces search space from O(f2max * f3max) to O(f2max + f3max)
+      size_t x = f5;
+      while (x*2 <= n) x *= 2;
+      if (x > bestfound) bestfound = x;
+      while (x <= n && x&1==0)
+      {
+        (x*3 <= n) ? (x *= 3) : (x /= 2);
+        if (x > bestfound) bestfound = x;
+      }
+      f5 *= 5;
+    }
+    return bestfound;
+  }
+
   static size_t prod(const shape_t &shape)
     {
     size_t res=1;

--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -7,7 +7,10 @@ Copyright (C) 2019-2020 Peter Bell
 For the odd-sized DCT-IV transforms:
   Copyright (C) 2003, 2007-14 Matteo Frigo
   Copyright (C) 2003, 2007-14 Massachusetts Institute of Technology
-
+  
+For the prev_good_size search:
+  Copyright (C) 2024 Tan Ping Liang, Peter Bell
+	
 Authors: Martin Reinecke, Peter Bell
 
 All rights reserved.

--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -10,7 +10,7 @@ For the odd-sized DCT-IV transforms:
   
 For the prev_good_size search:
   Copyright (C) 2024 Tan Ping Liang, Peter Bell
-	
+
 Authors: Martin Reinecke, Peter Bell
 
 All rights reserved.
@@ -463,7 +463,7 @@ struct util // hack to avoid duplicate symbols
     if (n<=12) return n;
 
     size_t bestfound = 1;
-	for (size_t f11 = 1;f11 <= n; f11 *= 11)
+    for (size_t f11 = 1;f11 <= n; f11 *= 11)
       for (size_t f117 = f11; f117 <= n; f117 *= 7)
         for (size_t f1175 = f117; f1175 <= n; f1175 *= 5)
         {

--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -472,14 +472,14 @@ struct util // hack to avoid duplicate symbols
           size_t x = f1175;
           while (x*2 <= n) x *= 2;
           if (x > bestfound) bestfound = x;
-            while (true) 
-            {
-              if (x * 3 <= n) x *= 3;
-              else if (x % 2 == 0) x /= 2;
-              else break;
-                
-              if (x > bestfound) bestfound = x;
-            }
+          while (true) 
+          {
+            if (x * 3 <= n) x *= 3;
+            else if (x % 2 == 0) x /= 2;
+            else break;
+              
+            if (x > bestfound) bestfound = x;
+          }
           f1175 *= 5;
         }
         f117 *= 7;
@@ -501,14 +501,14 @@ struct util // hack to avoid duplicate symbols
       size_t x = f5;
       while (x*2 <= n) x *= 2;
       if (x > bestfound) bestfound = x;
-	  while (true) 
-	  {
-	    if (x * 3 <= n) x *= 3;
-	    else if (x % 2 == 0) x /= 2;
-	    else break;
-	  
-	    if (x > bestfound) bestfound = x;
-	  }
+      while (true) 
+      {
+        if (x * 3 <= n) x *= 3;
+        else if (x % 2 == 0) x /= 2;
+        else break;
+      
+        if (x > bestfound) bestfound = x;
+      }
       f5 *= 5;
     }
     return bestfound;


### PR DESCRIPTION
**Reference Issue:**
see https://github.com/scipy/scipy/pull/15321

**What does this implement/fix?**
`pocketfft` currently implements a `good_size_real` and `good_size_cmplx` to find the smallest fast FFT length _greater than_ a N. 
These functions are useful for zero-padding signals to a length suitable for fast FFT.
However, in some situations it is easier to cut signals instead of zero-padding to reduce them to a fast FFT length. 
This PR implements `prev_good_size_real` and `prev_good_size_cmplx` to find the largest fast FFT length _smaller than_ N.