### PR TITLE
BUG: MAC version preprocessor shim

### DIFF
--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -153,7 +153,7 @@ template<> struct VLEN<double> { static constexpr size_t val=2; };
 // the standard C++ library on Windows does not provide aligned_alloc() even
 // though the MinGW compiler and MSVC may advertise C++17 compliance.
 // aligned_alloc is only supported from MacOS 10.15.
-#if (__cplusplus >= 201703L) && (!defined(__MINGW32__)) && (!defined(_MSC_VER)) && (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15)
+#if (__cplusplus >= 201703L) && (!defined(__MINGW32__)) && (!defined(_MSC_VER)) && (__MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15)
 inline void *aligned_alloc(size_t align, size_t size)
   {
   // aligned_alloc() requires that the requested size is a multiple of "align"


### PR DESCRIPTION
"Upstream" version of https://github.com/scipy/pocketfft/pull/1 (@lucascolley suggested we at least flush the CI, regardless of where we merge it, if we merge it..)

* tries to address this: https://github.com/scipy/scipy/issues/20300

* I needed the preceding underscores added here to produce `__MAC_OS_X_VERSION_MIN_REQUIRED` and actually populate a value into this preprocessor "variable"

* After that adjustment locally, I see this from carefully crafted pragma messages: `__MAC_OS_X_VERSION_MIN_REQUIRED: 140000` and `MAC_OS_X_VERSION_10_15: 101500 ` (the latter "variable" was already populated)

* of course, I'm on a way newer MacOS (14.4) than the problem this patch attempts to deal with, but to be fair I was reproducing the problem of `MAC_OS_VERSION_MIN_REQUIRED` not being populated with a constant value nonetheless