### PR TITLE
Avoid overflow in good_size... functions

### DIFF
--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -61,6 +61,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <complex>
 #include <algorithm>
+#include <limits>
 #if POCKETFFT_CACHE_SIZE!=0
 #include <array>
 #include <mutex>
@@ -401,17 +402,31 @@ struct util // hack to avoid duplicate symbols
     return result*double(ni);
     }
 
-  /* returns the smallest composite of 2, 3, 5, 7 and 11 which is >= n */
-  static POCKETFFT_NOINLINE size_t good_size_cmplx(size_t n)
+  /* inner workings of good_size_cmplx() */
+  template<typename UIntT>
+  static POCKETFFT_NOINLINE UIntT good_size_cmplx_typed(UIntT n)
     {
     if (n<=12) return n;
+    if (n>std::numeric_limits<UIntT>::max()/11/2)
+      {
+      // The algorithm below doesn't work for this value, the multiplication can overflow.
+      if (sizeof(UIntT)==4)
+        {
+        // We can try using this algorithm with 64-bit integers:
+        std::uint64_t res = good_size_cmplx_typed<std::uint64_t>(n);
+        if (res<=std::numeric_limits<UIntT>::max())
+          return static_cast<UIntT>(res);
+        }
+      // Otherwise, this size is ridiculously large, people shouldn't be computing FFTs this large.
+      throw std::runtime_error("FFT size is too large.");
+      }
 
-    size_t bestfac=2*n;
-    for (size_t f11=1; f11<bestfac; f11*=11)
-      for (size_t f117=f11; f117<bestfac; f117*=7)
-        for (size_t f1175=f117; f1175<bestfac; f1175*=5)
+    UIntT bestfac=2*n;
+    for (UIntT f11=1; f11<bestfac; f11*=11)
+      for (UIntT f117=f11; f117<bestfac; f117*=7)
+        for (UIntT f1175=f117; f1175<bestfac; f1175*=5)
           {
-          size_t x=f1175;
+          UIntT x=f1175;
           while (x<n) x*=2;
           for (;;)
             {
@@ -429,6 +444,11 @@ struct util // hack to avoid duplicate symbols
           }
     return bestfac;
     }
+  /* returns the smallest composite of 2, 3, 5, 7 and 11 which is >= n */
+  static POCKETFFT_NOINLINE size_t good_size_cmplx(size_t n)
+    {
+    return good_size_cmplx_typed(n);
+    }
   /* returns the smallest composite of 2, 3, 5, 7 and 11 which is >= n
      and a multiple of required_factor. */
   static POCKETFFT_NOINLINE size_t good_size_cmplx(size_t n,
@@ -439,15 +459,29 @@ struct util // hack to avoid duplicate symbols
     return good_size_cmplx((n+required_factor-1)/required_factor) * required_factor;
     }
 
-  /* returns the smallest composite of 2, 3, 5 which is >= n */
-  static POCKETFFT_NOINLINE size_t good_size_real(size_t n)
+  /* inner workings of good_size_real() */
+  template<typename UIntT>
+  static POCKETFFT_NOINLINE UIntT good_size_real_typed(UIntT n)
     {
     if (n<=6) return n;
+    if (n>std::numeric_limits<UIntT>::max()/5/2)
+    {
+      // The algorithm below doesn't work for this value, the multiplication can overflow.
+      if (sizeof(UIntT)==4)
+        {
+        // We can try using this algorithm with 64-bit integers:
+        std::uint64_t res = good_size_real_typed<std::uint64_t>(n);
+        if (res<=std::numeric_limits<UIntT>::max())
+          return static_cast<UIntT>(res);
+        }
+      // Otherwise, this size is ridiculously large, people shouldn't be computing FFTs this large.
+      throw std::runtime_error("FFT size is too large.");
+    }
 
-    size_t bestfac=2*n;
-    for (size_t f5=1; f5<bestfac; f5*=5)
+    UIntT bestfac=2*n;
+    for (UIntT f5=1; f5<bestfac; f5*=5)
       {
-      size_t x = f5;
+      UIntT x = f5;
       while (x<n) x *= 2;
       for (;;)
         {
@@ -465,6 +499,11 @@ struct util // hack to avoid duplicate symbols
       }
     return bestfac;
     }
+  /* returns the smallest composite of 2, 3, 5 which is >= n */
+  static POCKETFFT_NOINLINE size_t good_size_real(size_t n)
+    {
+    return good_size_real_typed(n);
+    }
   /* returns the smallest composite of 2, 3, 5 which is >= n
      and a multiple of required_factor. */
   static POCKETFFT_NOINLINE size_t good_size_real(size_t n,
@@ -475,53 +514,91 @@ struct util // hack to avoid duplicate symbols
     return good_size_real((n+required_factor-1)/required_factor) * required_factor;
     }
 
-  /* returns the largest composite of 2, 3, 5, 7 and 11 which is <= n */
-  static POCKETFFT_NOINLINE size_t prev_good_size_cmplx(size_t n)
-  {
+  /* inner workings of prev_good_size_cmplx() */
+  template<typename UIntT>
+  static POCKETFFT_NOINLINE UIntT prev_good_size_cmplx_typed(UIntT n)
+    {
     if (n<=12) return n;
+    if (n>std::numeric_limits<UIntT>::max()/11)
+    {
+      // The algorithm below doesn't work for this value, the multiplication can overflow.
+      if (sizeof(UIntT)==4)
+      {
+        // We can try using this algorithm with 64-bit integers:
+        std::uint64_t res = prev_good_size_cmplx_typed<std::uint64_t>(n);
+        if (res<=std::numeric_limits<UIntT>::max())
+          return static_cast<UIntT>(res);
+      }
+      // Otherwise, this size is ridiculously large, people shouldn't be computing FFTs this large.
+      throw std::runtime_error("FFT size is too large.");
+    }
 
-    size_t bestfound = 1;
-    for (size_t f11 = 1;f11 <= n; f11 *= 11)
-      for (size_t f117 = f11; f117 <= n; f117 *= 7)
-        for (size_t f1175 = f117; f1175 <= n; f1175 *= 5)
-        {
-          size_t x = f1175;
+    UIntT bestfound = 1;
+    for (UIntT f11 = 1;f11 <= n; f11 *= 11)
+      for (UIntT f117 = f11; f117 <= n; f117 *= 7)
+        for (UIntT f1175 = f117; f1175 <= n; f1175 *= 5)
+          {
+          UIntT x = f1175;
           while (x*2 <= n) x *= 2;
           if (x > bestfound) bestfound = x;
           while (true) 
-          {
+            {
             if (x * 3 <= n) x *= 3;
             else if (x % 2 == 0) x /= 2;
             else break;
               
             if (x > bestfound) bestfound = x;
+            }
           }
-        }
     return bestfound;
-  }
-
-  /* returns the largest composite of 2, 3, 5 which is <= n */
-  static POCKETFFT_NOINLINE size_t prev_good_size_real(size_t n)
-  {
-    if (n<=6) return n;
-
-    size_t bestfound = 1;
-    for (size_t f5 = 1; f5 <= n; f5 *= 5)
+    }
+  /* returns the largest composite of 2, 3, 5, 7 and 11 which is <= n */
+  static POCKETFFT_NOINLINE size_t prev_good_size_cmplx(size_t n)
     {
-      size_t x = f5;
+    return prev_good_size_cmplx_typed(n);
+    }
+
+  /* inner workings of prev_good_size_real() */
+  template<typename UIntT>
+  static POCKETFFT_NOINLINE UIntT prev_good_size_real_typed(UIntT n)
+    {
+    if (n<=6) return n;
+    if (n>std::numeric_limits<UIntT>::max()/5)
+    {
+      // The algorithm below doesn't work for this value, the multiplication can overflow.
+      if (sizeof(UIntT)==4)
+      {
+        // We can try using this algorithm with 64-bit integers:
+        std::uint64_t res = prev_good_size_real_typed<std::uint64_t>(n);
+        if (res<=std::numeric_limits<UIntT>::max())
+          return static_cast<UIntT>(res);
+      }
+      // Otherwise, this size is ridiculously large, people shouldn't be computing FFTs this large.
+      throw std::runtime_error("FFT size is too large.");
+    }
+
+    UIntT bestfound = 1;
+    for (UIntT f5 = 1; f5 <= n; f5 *= 5)
+      {
+      UIntT x = f5;
       while (x*2 <= n) x *= 2;
       if (x > bestfound) bestfound = x;
       while (true) 
-      {
+        {
         if (x * 3 <= n) x *= 3;
         else if (x % 2 == 0) x /= 2;
         else break;
       
         if (x > bestfound) bestfound = x;
+        }
       }
-    }
     return bestfound;
-  }
+    }
+  /* returns the largest composite of 2, 3, 5 which is <= n */
+  static POCKETFFT_NOINLINE size_t prev_good_size_real(size_t n)
+    {
+    return prev_good_size_real_typed(n);
+    }
 
   static size_t prod(const shape_t &shape)
     {


### PR DESCRIPTION
This should fix issue #15 in the manner discussed there.

I tried to follow the existing code style, but feel free to reformat or edit in any way.

In my own version of these functions, I combined the code for `_cmplx` and `_real` by making the maximum factor a template parameter as well. That reduces code duplication a bit. I'm happy to do that here too if you like.

This was my test program, for posterity:
```cpp
#include <iostream>
#include "pocketfft_hdronly.h"

int main() {
    std::size_t res;
    res = pocketfft::detail::util::good_size_real(10);
    std::cout << "good_size_real(10): " << res << ", correct: " << (10 == res) << '\n';
    res = pocketfft::detail::util::good_size_real(11);
    std::cout << "good_size_real(11): " << res << ", correct: " << (12 == res) << '\n';
    res = pocketfft::detail::util::good_size_real(13);
    std::cout << "good_size_real(13): " << res << ", correct: " << (15 == res) << '\n';
    res = pocketfft::detail::util::good_size_real(101);
    std::cout << "good_size_real(101): " << res << ", correct: " << (108 == res) << '\n';
    res = pocketfft::detail::util::good_size_real(2109375001u);
    std::cout << "good_size_real(2109375001): " << res << ", correct: " << (2123366400u == res) << '\n';
    res = pocketfft::detail::util::good_size_real(4294967295u/5/2); // does the work in the 32-bit algorithm
    std::cout << "good_size_real(4294967295/5/2): " << res << ", correct: " << (429981696 == res) << '\n';
    res = pocketfft::detail::util::good_size_real(4294967295u/5/2+1); // should be elevated to the 64-bit algorithm
    std::cout << "good_size_real(4294967295/5/2+1): " << res << ", correct: " << (429981696 == res) << '\n';
    // Throws in the 32-bit case:
    try {
        res = pocketfft::detail::util::good_size_real(4294967295);
        std::cout << "good_size_real(4294967295): " << res << ", correct: " << (4294967296 == res) << '\n';
    } catch (std::runtime_error const& err) {
        std::cout << "good_size_real(4294967295) throws.\n";
    }

    res = pocketfft::detail::util::good_size_cmplx(10);
    std::cout << "good_size_cmplx(10): " << res << ", correct: " << (10 == res) << '\n';
    res = pocketfft::detail::util::good_size_cmplx(11);
    std::cout << "good_size_cmplx(11): " << res << ", correct: " << (11 == res) << '\n';
    res = pocketfft::detail::util::good_size_cmplx(13);
    std::cout << "good_size_cmplx(13): " << res << ", correct: " << (14 == res) << '\n';
    res = pocketfft::detail::util::good_size_cmplx(101);
    std::cout << "good_size_cmplx(101): " << res << ", correct: " << (105 == res) << '\n';
    res = pocketfft::detail::util::good_size_cmplx(2109375001u);
    std::cout << "good_size_cmplx(2109375001): " << res << ", correct: " << (2112000000u == res) << '\n';
    res = pocketfft::detail::util::good_size_cmplx(4294967295u/11/2); // does the work in the 32-bit algorithm
    std::cout << "good_size_cmplx(4294967295/11/2): " << res << ", correct: " << (195230112 == res) << '\n';
    res = pocketfft::detail::util::good_size_cmplx(4294967295u/11/2+1); // should be elevated to the 64-bit algorithm
    std::cout << "good_size_cmplx(4294967295/11/2+1): " << res << ", correct: " << (195230112 == res) << '\n';
    // Throws in the 32-bit case:
    try {
        res = pocketfft::detail::util::good_size_cmplx(4294967295);
        std::cout << "good_size_cmplx(4294967295): " << res << ", correct: " << (4294967296 == res) << '\n';
    } catch (std::runtime_error const& err) {
        std::cout << "good_size_real(4294967295) throws.\n";
    }

    res = pocketfft::detail::util::prev_good_size_real(10);
    std::cout << "prev_good_size_real(10): " << res << ", correct: " << (10 == res) << '\n';
    res = pocketfft::detail::util::prev_good_size_real(11);
    std::cout << "prev_good_size_real(11): " << res << ", correct: " << (10 == res) << '\n';
    res = pocketfft::detail::util::prev_good_size_real(13);
    std::cout << "prev_good_size_real(13): " << res << ", correct: " << (12 == res) << '\n';
    res = pocketfft::detail::util::prev_good_size_real(107);
    std::cout << "prev_good_size_real(107): " << res << ", correct: " << (100 == res) << '\n';
    res = pocketfft::detail::util::prev_good_size_real(2123366399u);
    std::cout << "prev_good_size_real(2123366399): " << res << ", correct: " << (2109375000u == res) << '\n';
    res = pocketfft::detail::util::prev_good_size_real(4294967295u/5); // does the work in the 32-bit algorithm
    std::cout << "prev_good_size_real(4294967295/5): " << res << ", correct: " << (854296875 == res) << '\n';
    res = pocketfft::detail::util::prev_good_size_real(4294967295u/5+1); // should be elevated to the 64-bit algorithm
    std::cout << "prev_good_size_real(4294967295/5+1): " << res << ", correct: " << (854296875 == res) << '\n';

    res = pocketfft::detail::util::prev_good_size_cmplx(10);
    std::cout << "prev_good_size_cmplx(10): " << res << ", correct: " << (10 == res) << '\n';
    res = pocketfft::detail::util::prev_good_size_cmplx(11);
    std::cout << "prev_good_size_cmplx(11): " << res << ", correct: " << (11 == res) << '\n';
    res = pocketfft::detail::util::prev_good_size_cmplx(13);
    std::cout << "prev_good_size_cmplx(13): " << res << ", correct: " << (12 == res) << '\n';
    res = pocketfft::detail::util::prev_good_size_cmplx(107);
    std::cout << "prev_good_size_cmplx(107): " << res << ", correct: " << (105 == res) << '\n';
    res = pocketfft::detail::util::prev_good_size_cmplx(2123366399u);
    std::cout << "prev_good_size_cmplx(2123366399): " << res << ", correct: " << (2122312500u == res) << '\n';
    res = pocketfft::detail::util::prev_good_size_cmplx(4294967295u/11); // does the work in the 32-bit algorithm
    std::cout << "prev_good_size_cmplx(4294967295/11): " << res << ", correct: " << (390297600 == res) << '\n';
    res = pocketfft::detail::util::prev_good_size_cmplx(4294967295u/11+1); // should be elevated to the 64-bit algorithm
    std::cout << "prev_good_size_cmplx(4294967295/11+1): " << res << ", correct: " << (390297600 == res) << '\n';
    res = pocketfft::detail::util::prev_good_size_cmplx(4294967295u);
    std::cout << "prev_good_size_cmplx(4294967295): " << res << ", correct: " << (4293273600u == res) << '\n';
}
```