### PR TITLE
Add missing include

### DIFF
--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -56,6 +56,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cmath>
 #include <cstdlib>
+#include <exception>
 #include <stdexcept>
 #include <memory>
 #include <vector>


### PR DESCRIPTION
Added missing <exception> include which prevented the library from being compiled successfully using recent version of libcxx.
Found during the upgrade of ClickHouse's LLVM dependency to 18.x version. 

```
/home/ubuntu/ClickHouse/ClickHouse/contrib/pocketfft/pocketfft_hdronly.h:796:22: error: variable has incomplete type 'std::exception_ptr'
  796 |   std::exception_ptr ex;
      |                      ^
/home/ubuntu/ClickHouse/ClickHouse/contrib/llvm-project/libcxx/include/__exception/operations.h:36:33: note: forward declaration of 'std::exception_ptr'
   36 | class _LIBCPP_EXPORTED_FROM_ABI exception_ptr;
      |                                 ^
In file included from /home/ubuntu/ClickHouse/ClickHouse/src/Functions/seriesPeriodDetectFFT.cpp:9:
/home/ubuntu/ClickHouse/ClickHouse/contrib/pocketfft/pocketfft_hdronly.h:808:14: error: calling 'current_exception' with incomplete return type 'exception_ptr'
  808 |         ex = std::current_exception();
      |              ^~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/ClickHouse/ClickHouse/contrib/llvm-project/libcxx/include/__exception/operations.h:38:41: note: 'current_exception' declared here
   38 | _LIBCPP_EXPORTED_FROM_ABI exception_ptr current_exception() _NOEXCEPT;
      |                                         ^
/home/ubuntu/ClickHouse/ClickHouse/contrib/llvm-project/libcxx/include/__exception/operations.h:36:33: note: forward declaration of 'std::exception_ptr'
   36 | class _LIBCPP_EXPORTED_FROM_ABI exception_ptr;
```