### PR TITLE
Fix a missing <cstddef> include

### DIFF
--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -59,6 +59,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cmath>
 #include <cstdlib>
+#include <cstddef>
 #include <exception>
 #include <stdexcept>
 #include <memory>


### PR DESCRIPTION
Fixes a compilation error on GCC 5 due to `max_align_t` from `<cstddef>` not being found.

Related to https://github.com/conan-io/conan-center-index/pull/24769