### PR TITLE
Fix align on Apple platforms

### DIFF
--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -162,8 +162,20 @@ template<> struct VLEN<double> { static constexpr size_t val=2; };
 // std::aligned_alloc is a bit cursed ... it doesn't exist on MacOS < 10.15
 // and in musl, and other OSes seem to have even more peculiarities.
 // Let's unconditionally work around it for now.
-# if 0
-//#if (__cplusplus >= 201703L) && (!defined(__MINGW32__)) && (!defined(_MSC_VER)) && (__MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15)
+#if defined(__APPLE__) || defined(__unix__)
+// Use posix_memalign on POSIX systems - it is ASAN-compatible.
+// The portable aligned_alloc below stores metadata at ptr[-1], which conflicts
+// with ASAN's heap redzone and causes intermittent bus errors.
+inline void *aligned_alloc(size_t align, size_t size)
+  {
+  void *ptr = nullptr;
+  if (posix_memalign(&ptr, align, size) != 0)
+    throw std::bad_alloc();
+  return ptr;
+  }
+inline void aligned_dealloc(void *ptr)
+    { free(ptr); }
+#elif (__cplusplus >= 201703L) && (!defined(__MINGW32__)) && (!defined(_MSC_VER))
 inline void *aligned_alloc(size_t align, size_t size)
   {
   // aligned_alloc() requires that the requested size is a multiple of "align"
@@ -173,7 +185,7 @@ inline void *aligned_alloc(size_t align, size_t size)
   }
 inline void aligned_dealloc(void *ptr)
     { free(ptr); }
-#else // portable emulation
+#else // portable emulation (NOT ASAN-compatible - stores metadata at ptr[-1])
 inline void *aligned_alloc(size_t align, size_t size)
   {
   align = std::max(align, alignof(max_align_t));

--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -162,8 +162,8 @@ template<> struct VLEN<double> { static constexpr size_t val=2; };
 // std::aligned_alloc is a bit cursed ... it doesn't exist on MacOS < 10.15
 // and in musl, and other OSes seem to have even more peculiarities.
 // Let's unconditionally work around it for now.
-#if defined(__APPLE__) || defined(__unix__)
-// Use posix_memalign on POSIX systems - it is ASAN-compatible.
+#if defined(POCKETFFT_USE_POSIX_MEMALIGN) && (defined(__APPLE__) || defined(__unix__))
+// Use posix_memalign on POSIX systems when explicitly enabled.
 // The portable aligned_alloc below stores metadata at ptr[-1], which conflicts
 // with ASAN's heap redzone and causes intermittent bus errors.
 inline void *aligned_alloc(size_t align, size_t size)
@@ -176,7 +176,9 @@ inline void *aligned_alloc(size_t align, size_t size)
   }
 inline void aligned_dealloc(void *ptr)
     { free(ptr); }
-#elif (__cplusplus >= 201703L) && (!defined(__MINGW32__)) && (!defined(_MSC_VER))
+#else
+# if 0
+//#if (__cplusplus >= 201703L) && (!defined(__MINGW32__)) && (!defined(_MSC_VER)) && (__MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15)
 inline void *aligned_alloc(size_t align, size_t size)
   {
   // aligned_alloc() requires that the requested size is a multiple of "align"
@@ -186,7 +188,7 @@ inline void *aligned_alloc(size_t align, size_t size)
   }
 inline void aligned_dealloc(void *ptr)
     { free(ptr); }
-#else // portable emulation (NOT ASAN-compatible - stores metadata at ptr[-1])
+#else // portable emulation
 inline void *aligned_alloc(size_t align, size_t size)
   {
   align = std::max(align, alignof(max_align_t));
@@ -199,6 +201,7 @@ inline void *aligned_alloc(size_t align, size_t size)
   }
 inline void aligned_dealloc(void *ptr)
   { if (ptr) free((reinterpret_cast<void**>(ptr))[-1]); }
+# endif
 #endif
 
 template<typename T> class arr

--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -168,6 +168,7 @@ template<> struct VLEN<double> { static constexpr size_t val=2; };
 // with ASAN's heap redzone and causes intermittent bus errors.
 inline void *aligned_alloc(size_t align, size_t size)
   {
+  align = std::max(align, sizeof(void*)); // posix_memalign requires align >= sizeof(void*)
   void *ptr = nullptr;
   if (posix_memalign(&ptr, align, size) != 0)
     throw std::bad_alloc();


### PR DESCRIPTION
This PR applies pocketfft patch for ASAN-compatible aligned_alloc on POSIX systems. The portable aligned_alloc in pocketfft stores metadata at ptr[-1], which conflicts with ASAN's heap redzone and causes intermittent bus errors. This patch uses posix_memalign instead, which is ASAN-compatible.