### PR TITLE
Make pocketfft namespace customizable using POCKETFFT_NAMESPACE definition

### DIFF
--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -53,6 +53,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #error This file requires at least C++11 support.
 #endif
 
+#ifndef POCKETFFT_NAMESPACE
+#define POCKETFFT_NAMESPACE pocketfft
+#endif
+
 #ifndef POCKETFFT_CACHE_SIZE
 #define POCKETFFT_CACHE_SIZE 0
 #endif
@@ -98,7 +102,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define POCKETFFT_RESTRICT
 #endif
 
-namespace pocketfft {
+namespace POCKETFFT_NAMESPACE {
 
 namespace detail {
 using std::size_t;


### PR DESCRIPTION
This modification allows to include `pocketfft_hdronly.h` as a **private** implementation detail in a `.cpp` file, in order to avoid possible linking conflicts of multiple libraries using pocketfft, possibly at a different version/commit-id.

```c++
// file: mylib_fft.hpp

namespace mylib {
    void inverse_fft_c2r(size_t /*size_out*/, std::complex<double>* /*in*/, double* /*out*/ );
}
```
```c++
// file: mylib_fft.cpp

#define POCKETFFT_NAMESPACE mylib::pocketfft
#include "pocketfft_headeronly.h"
namespace mylib {
    void inverse_fft_c2r(size_t /*size_out*/, std::complex<double>* /*in*/, double* /*out*/ ) {
         pocketfft::c2r( /*pocketfft args omitted*/ );
    }
}
```