### PR TITLE
Enable RISC-V Vector (RVV) auto-vectorization

### DIFF
--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -158,6 +158,9 @@ template<> struct VLEN<double> { static constexpr size_t val=2; };
 #elif (defined(__ARM_NEON__) || defined(__ARM_NEON))
 template<> struct VLEN<float> { static constexpr size_t val=4; };
 template<> struct VLEN<double> { static constexpr size_t val=2; };
+#elif (defined(__riscv_vector) || defined(__riscv_v_intrinsic))
+template<> struct VLEN<float> { static constexpr size_t val=8; };
+template<> struct VLEN<double> { static constexpr size_t val=4; };
 #else
 #define POCKETFFT_NO_VECTORS
 #endif


### PR DESCRIPTION
Adds a RISC-V `#elif` branch to the `VLEN<T>` dispatch table so builds for `rv64gcv` targets pick up the `vector_size` auto-vectorization path instead of falling through to `POCKETFFT_NO_VECTORS`. `VLEN<float>=8` / `VLEN<double>=4` matches the 256-bit minimum VLEN of the RVA22V / RVA23 profiles.

Hardware without the V extension does not define `__riscv_vector` and continues to land in the existing `#else` branch, so this is a no-op on V-less RISC-V CPUs.

Measured on SpacemiT K3 (X100 cluster, RVA22V, VLEN=256, 2.4 GHz), N=4194304 c2c forward, 10 reps × 3 runs, governor=performance, cooldown ≤ 65 °C, GCC 15.2 `-O3 -march=rv64gcv_zvl256b`:

| build | per-call (best of 3) | speedup |
|---|---:|---:|
| `POCKETFFT_NO_VECTORS` (no library SIMD) | 488.48 ms | 1.000× |
| this patch (`vector_size` autovec) | **440.96 ms** | **1.108×** |

GCC 15.2 emits `vlseg2e32.v` / `vsseg2e32.v` segment load/store for the `cmplx<float>` AoS layout and a 4-FMA `vfmul` / `vfmadd` / `vfmsub` chain for the twiddle multiply — the RVV equivalent of the NEON `vld2q_f32` pattern already exercised by the existing `__ARM_NEON` branch. Clang 22 cross-compile produces equivalent codegen (`vlseg2e32.v` plus vector-scalar `vfmacc.vf`).

A truly VLEN-agnostic version (querying VL via `vsetvli` at runtime so smaller-VLEN cores like SpacemiT K1 / VLEN=128 don't waste lanes the other direction) would be a natural follow-up, but is out of scope for this minimal enable.
