### PR TITLE
Use nullptr instead of 0 in arr default constructor

### DIFF
--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -239,7 +239,7 @@ template<typename T> class arr
 #endif
 
   public:
-    arr() : p(0), sz(0) {}
+    arr() : p(nullptr), sz(0) {}
     explicit arr(size_t n) : p(ralloc(n)), sz(n) {}
     arr(arr &&other) noexcept
       : p(other.p), sz(other.sz)


### PR DESCRIPTION
Initialize `arr<T>::p` with `nullptr` instead of the literal `0` in the default constructor, silencing `-Wzero-as-null-pointer-constant` in strict downstream builds.

<details>
<summary>Why</summary>

The `arr() : p(0), sz(0) {}` constructor initializes a pointer member from the integer literal `0`. Compilers with `-Wzero-as-null-pointer-constant` enabled (e.g. ITK's AppleClang nightly dashboard, where `pocketfft_hdronly.h` is vendored) emit a warning at every template instantiation of `arr<T>`, producing a large warning + instantiation-backtrace cascade.

`nullptr` is C++11, so the header remains strictly C++11 compliant (enforced by the existing `#error This file requires at least C++11 support.` guard).
</details>

<details>
<summary>How / verification</summary>

- Change produced by `clang-tidy -checks='-*,modernize-use-nullptr' --fix`; it is the only `0`-as-pointer pattern in the header.
- `pocketfft_demo.cc` builds clean (`-Wall -Wextra`) and runs identically (L2 errors ~1e-7) at both `-std=c++11` and `-std=c++17`.
- `-Wzero-as-null-pointer-constant` count drops from non-zero to 0 after the change.
</details>
